### PR TITLE
Karma support

### DIFF
--- a/bin/vbuild-default.js
+++ b/bin/vbuild-default.js
@@ -1,0 +1,16 @@
+'use strict'
+const chalk = require('chalk')
+const main = require('../lib')
+
+module.exports = (input, flags) => {
+  const options = Object.assign({
+    entry: input[0],
+    input: input,
+  }, flags)
+  return main(options).catch(e => {
+    console.log(chalk.red(e.stack))
+    if (!cli.dev && !cli.watch) {
+      process.exit(1)
+    }
+  })
+}

--- a/bin/vbuild-init.js
+++ b/bin/vbuild-init.js
@@ -1,0 +1,13 @@
+'use strict'
+const chalk = require('chalk')
+const init = require('../lib/init')
+
+module.exports = (input, flags) => {
+  const options = Object.assign({
+    projectName: input[0]
+  }, flags)
+  return init(options).catch(err => {
+    console.error(chalk.red(err.stack))
+    process.exit(1)
+  })
+}

--- a/bin/vbuild-test.js
+++ b/bin/vbuild-test.js
@@ -4,12 +4,12 @@ const main = require('../lib')
 
 module.exports = (input, flags) => {
   const options = Object.assign({
-    entry: input[0]
+    inputFiles: input,
+    dev: true,
+    test: true
   }, flags)
-  return main(options).catch(e => {
-    console.log(chalk.red(e.stack))
-    if (!cli.dev && !cli.watch) {
-      process.exit(1)
-    }
+  return main(options).catch(err => {
+    console.error(chalk.red(err.stack))
+    process.exit(1)
   })
 }

--- a/bin/vbuild.js
+++ b/bin/vbuild.js
@@ -3,9 +3,7 @@
 const cac = require('cac')
 const chalk = require('chalk')
 const update = require('update-notifier')
-const main = require('./lib')
-const pkg = require('./package')
-const init = require('./lib/init')
+const pkg = require('../package')
 
 update({pkg}).notify()
 
@@ -13,6 +11,7 @@ const cli = cac()
 
 cli
   .option('dev, d', 'Run in dev mode')
+  .option('test', 'Run in test mode')
   .option('port, p', 'Run in dev mode')
   .option('watch, w', 'Run in watch mode')
   .option('clean', 'Clean dist directory before bundling')
@@ -41,5 +40,7 @@ cli
 cli.usage(`${chalk.yellow('vbuild')} [entry] [options]`)
 cli.example('vbuild --dev --css-modules --template ./template.html')
 
-cli.parse()
+cli.command('*', 'Run vbuild')
+cli.command('init', 'Create a new project')
 
+cli.parse()

--- a/bin/vbuild.js
+++ b/bin/vbuild.js
@@ -11,7 +11,6 @@ const cli = cac()
 
 cli
   .option('dev, d', 'Run in dev mode')
-  .option('test', 'Run in test mode')
   .option('port, p', 'Run in dev mode')
   .option('watch, w', 'Run in watch mode')
   .option('clean', 'Clean dist directory before bundling')
@@ -42,5 +41,6 @@ cli.example('vbuild --dev --css-modules --template ./template.html')
 
 cli.command('*', 'Run vbuild')
 cli.command('init', 'Create a new project')
+cli.command('test', 'Run tests')
 
 cli.parse()

--- a/lib/addons.js
+++ b/lib/addons.js
@@ -10,7 +10,7 @@ module.exports = (config, options) => {
       loaders: ['eslint'],
       exclude: [/node_modules/],
       query: Object.assign({
-        configFile: require.resolve('eslint-config-rem/exnext-browser')
+        configFile: require.resolve('eslint-config-rem/esnext-browser')
       }, options.eslint)
     })
   }

--- a/lib/addons.js
+++ b/lib/addons.js
@@ -23,8 +23,8 @@ module.exports = (config, options) => {
     ))
   }
 
-   if (options.test) {
-      config.devtool = 'inline-source-map'
-      delete config.entry
-    }
+  if (options.test) {
+    config.devtool = 'inline-source-map'
+    delete config.entry
+  }
 }

--- a/lib/addons.js
+++ b/lib/addons.js
@@ -10,7 +10,7 @@ module.exports = (config, options) => {
       loaders: ['eslint'],
       exclude: [/node_modules/],
       query: Object.assign({
-        configFile: require.resolve('eslint-config-rem')
+        configFile: require.resolve('eslint-config-rem/exnext-browser')
       }, options.eslint)
     })
   }

--- a/lib/addons.js
+++ b/lib/addons.js
@@ -22,4 +22,9 @@ module.exports = (config, options) => {
       {}
     ))
   }
+
+   if (options.test) {
+      config.devtool = 'inline-source-map'
+      delete config.entry
+    }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,7 +24,11 @@ module.exports = co.wrap(function * (options) {
     try {
       options.config = require.resolve(options.config)
       fileConfig = require(options.config)
-    } catch (err) {}
+    } catch (err) {
+      if (err.code !== 'MODULE_NOT_FOUND') {
+        throw err
+      }
+    }
 
     if (fileConfig) {
       devConfig = fileConfig.development

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,12 +22,12 @@ module.exports = co.wrap(function * (options) {
   let devConfig
   let prodConfig
   if (options.config !== false) {
-    let configFilePath = options.config || defaultConfigPath
+    const configFilePath = options.config || defaultConfigPath
     try {
       fileConfig = require(_.cwd(configFilePath))
     } catch (err) {
-      if (err.code == 'MODULE_NOT_FOUND') {
-         options.config = chalk.red(`[not found] ${configFilePath}`)
+      if (err.code === 'MODULE_NOT_FOUND') {
+        options.config = chalk.red(`[not found] ${configFilePath}`)
       } else {
         throw err
       }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,31 +1,34 @@
 'use strict'
 const Path = require('path')
 const co = require('co')
+const chalk = require('chalk')
 const merge = require('lodash.merge')
 const build = require('./build')
 const dev = require('./dev')
+const test = require('./test')
 const updateConfig = require('./update-config')
 const detectFreePort = require('./detect-free-port')
 const mergeConfig = require('./merge-config')
+const _ = require('./utils')
 
 module.exports = co.wrap(function * (options) {
-  options.config = options.config === false ?
-    false :
-    Path.resolve(
-        typeof options.config === 'string' ?
-          options.config :
-          'vue.config'
-      )
+  const defaultConfigPath = Path.resolve(
+    typeof options.config === 'string' ?
+      options.config :
+      'vue.config'
+  )
 
   let fileConfig
   let devConfig
   let prodConfig
   if (options.config !== false) {
+    let configFilePath = options.config || defaultConfigPath
     try {
-      options.config = require.resolve(options.config)
-      fileConfig = require(options.config)
+      fileConfig = require(_.cwd(configFilePath))
     } catch (err) {
-      if (err.code !== 'MODULE_NOT_FOUND') {
+      if (err.code == 'MODULE_NOT_FOUND') {
+         options.config = chalk.red(`[not found] ${configFilePath}`)
+      } else {
         throw err
       }
     }
@@ -61,6 +64,10 @@ module.exports = co.wrap(function * (options) {
 
   buildOptions.dist = buildOptions.dist || 'dist'
 
+  if (buildOptions.test) {
+    buildOptions.dev = true
+  }
+
   // even in --watch mode we use webpack.config.prod
   // since it's simply rebuilding.
   let webpackConfig = buildOptions.dev ?
@@ -73,7 +80,9 @@ module.exports = co.wrap(function * (options) {
   // merge user provided webpack config
   webpackConfig = mergeConfig(webpackConfig, buildOptions)
 
-  if (buildOptions.dev) {
+  if (buildOptions.test) {
+    test(webpackConfig, buildOptions)
+  } else if (buildOptions.dev) {
     yield dev(webpackConfig, buildOptions)
   } else {
     yield build(webpackConfig, buildOptions)

--- a/lib/init.js
+++ b/lib/init.js
@@ -10,7 +10,7 @@ const _ = require('./utils')
 module.exports = co.wrap(function * (options) {
   if (!options.projectName) {
     console.error(chalk.red('\n  Please specific a projectName, eg: vbuild init my-project\n'))
-    process.exit(1)
+    process.exit(1)  // eslint-disable xo/no-process-exit
   }
 
   const dest = _.cwd(options.projectName)

--- a/lib/init.js
+++ b/lib/init.js
@@ -9,7 +9,8 @@ const _ = require('./utils')
 
 module.exports = co.wrap(function * (options) {
   if (!options.projectName) {
-    console.error(chalk.red('\nPlease specific a projectName, eg: vbuild init my-project\n'))
+    console.error(chalk.red('\n  Please specific a projectName, eg: vbuild init my-project\n'))
+    process.exit(1)
   }
 
   const dest = _.cwd(options.projectName)

--- a/lib/test.js
+++ b/lib/test.js
@@ -15,7 +15,7 @@ module.exports = function (webpackConfig, options) {
     preprocessors: input.reduce((current, next) => {
       current[next] = ['webpack', 'sourcemap']
       return current
-    },{}),
+    }, {}),
     webpack: webpackConfig,
     webpackMiddleware: {
       stats: 'normal'

--- a/lib/test.js
+++ b/lib/test.js
@@ -4,7 +4,7 @@ const _ = require('./utils')
 module.exports = function (webpackConfig, options) {
   const Server = require(_.cwd('node_modules/karma')).Server
 
-  const input = options.input.length > 0 || ['./src/**/*', './tests/**/*.test.js']
+  const inputFiles = options.inputFiles.length > 0 || ['./src/**/*', './tests/**/*.test.js']
 
   let karmaConfig = options.karmaConfig
 
@@ -21,8 +21,8 @@ module.exports = function (webpackConfig, options) {
     browsers: ['Chrome', 'PhantomJS'],
     frameworks: ['mocha', 'chai'],
     basePath: _.cwd(),
-    files: input,
-    preprocessors: input.reduce((current, next) => {
+    files: inputFiles,
+    preprocessors: inputFiles.reduce((current, next) => {
       current[next] = ['webpack', 'sourcemap']
       return current
     }, {}),

--- a/lib/test.js
+++ b/lib/test.js
@@ -6,6 +6,16 @@ module.exports = function (webpackConfig, options) {
 
   const input = options.input.length > 0 || ['./src/**/*', './tests/**/*.test.js']
 
+  let karmaConfig = options.karmaConfig
+
+  if (typeof karmaConfig === 'string') {
+    karmaConfig = require(_.cwd(options.karmaConfig))
+  }
+
+  if (karmaConfig === 'function') {
+    karmaConfig = karmaConfig(webpackConfig, options)
+  }
+
   const server = new Server(Object.assign({
     port: 5001,
     browsers: ['Chrome', 'PhantomJS'],
@@ -20,7 +30,7 @@ module.exports = function (webpackConfig, options) {
     webpackMiddleware: {
       stats: 'normal'
     }
-  }, options.karmaConfig), exitCode => {
+  }, karmaConfig), exitCode => {
     console.log('Karma has exited with ' + exitCode)
     process.exit(exitCode)
   })

--- a/lib/test.js
+++ b/lib/test.js
@@ -1,0 +1,28 @@
+'use strict'
+const _ = require('./utils')
+
+module.exports = function (webpackConfig, options) {
+  const Server = require(_.cwd('node_modules/karma')).Server
+
+  const input = options.input.length > 0 || ['./src/**/*', './tests/**/*.test.js']
+
+  const server = new Server(Object.assign({
+    port: 5001,
+    browsers: ['Chrome', 'PhantomJS'],
+    frameworks: ['mocha', 'chai'],
+    basePath: _.cwd(),
+    files: input,
+    preprocessors: input.reduce((current, next) => {
+      current[next] = ['webpack', 'sourcemap']
+      return current
+    },{}),
+    webpack: webpackConfig,
+    webpackMiddleware: {
+      stats: 'normal'
+    }
+  }, options.karmaConfig), exitCode => {
+    console.log('Karma has exited with ' + exitCode)
+    process.exit(exitCode)
+  })
+  server.start()
+}

--- a/lib/update-config.js
+++ b/lib/update-config.js
@@ -68,7 +68,7 @@ module.exports = co.wrap(function * (webpackConfig, options) {
   // html plugin
   // generate html for iife (web app) format
   // can be disabled via --disable-html
-  if (!options.disableHtml && !options.cjs && !options.umd) {
+  if (!options.disableHtml && !options.cjs && !options.umd && !options.test) {
     const htmlPlugin = require('./html-plugin')
 
     webpackConfig.plugins.push(htmlPlugin(options))

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "scripts": {
     "test": "jest && xo lib/*.js"
   },
-  "bin": "cli.js",
+  "bin": "bin/vbuild.js",
   "files": [
     "lib",
     "cli.js",
@@ -58,7 +58,7 @@
     "babel-preset-es2015": "^6.16.0",
     "babel-preset-stage-2": "^6.17.0",
     "babel-runtime": "^6.11.6",
-    "cac": "^2.3.2",
+    "cac": "^3.0.1",
     "chalk": "^1.1.3",
     "co": "^4.6.0",
     "compression-webpack-plugin": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "space": 2,
     "esnext": true,
     "rules": {
-      "xo/no-abusive-eslint-disable": 0
+      "xo/no-abusive-eslint-disable": 0,
+      "xo/no-process-exit": 0
     }
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vbuild",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Preset build tool for Vue.js apps.",
   "license": "MIT",
   "repository": "egoist/vbuild",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vbuild",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Preset build tool for Vue.js apps.",
   "license": "MIT",
   "repository": "egoist/vbuild",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1234,15 +1234,16 @@ bytes@2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/bytes/-/bytes-2.4.0.tgz#7d97196f9d5baf7f6935e25985549edd2a6c2339"
 
-cac@^2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/cac/-/cac-2.3.2.tgz#8826353e82ea8df6281bb30d8b46d60cbaa2b4fa"
+cac@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/cac/-/cac-3.0.1.tgz#e1c7d20d4e79d8638d6dd29a2c23d51e484cced8"
   dependencies:
     camelcase-keys "^3.0.0"
     chalk "^1.1.3"
     indent-string "^3.0.0"
     minimist "^1.2.0"
     read-pkg-up "^1.0.1"
+    suffix "^0.1.0"
     text-table "^0.2.0"
 
 caching-transform@^1.0.0:
@@ -6200,6 +6201,10 @@ style-loader@^0.13.1:
   resolved "https://registry.yarnpkg.com/style-loader/-/style-loader-0.13.1.tgz#468280efbc0473023cd3a6cd56e33b5a1d7fc3a9"
   dependencies:
     loader-utils "^0.2.7"
+
+suffix@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/suffix/-/suffix-0.1.0.tgz#3e46966de56af17600385e58db8ec659dd797907"
 
 supports-color@^0.2.0:
   version "0.2.0"


### PR DESCRIPTION
This is a new command: `vbuild test` or `vbuild test [files] [options]`

This feature does no introduce any new dependencies, all those stuffs require to install locally in your project, by default it uses:

- 'Chrome', 'PhantomJS'
- 'mocha', 'chai'
- webpack 2.1.0-beta.22

So you need to install these if you use default options:

```json
{
    "chai": "^3.5.0",
    "karma": "^1.3.0",
    "karma-chai": "^0.1.0",
    "karma-chrome-launcher": "^2.0.0",
    "karma-mocha": "^1.2.0",
    "karma-phantomjs-launcher": "^1.0.2",
    "karma-sourcemap-loader": "^0.3.7",
    "karma-webpack": "^1.8.0",
    "mocha": "^3.1.2",
    "webpack": "2.1.0-beta.22"
}
```