### PR TITLE
take `--port` into account when detecting target port

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ module.exports = co.wrap(function * (options) {
 
   process.env.NODE_ENV = isDev ? 'development' : 'production'
 
-  let port = 4000
+  let port = options.port || 4000
 
   if (options.dev) {
     port = yield detectFreePort(port)


### PR DESCRIPTION
When running vbuild in `--dev` with a custom port, it still checks the default port `4000` and barks, if somethings already running there. 
This lil commit changes the behaviour to have `--port`(or the `config.js` counterpart) take precedence over the default.

**Repro**
- fire something up on port 4000, ie: `python -mSimpleHTTPServer 4000`
- try to start vbuild on a custom port, ie: `vbuild --dev --port 3000`

**Expected**
vbuild just starts the dev server on port 3000 without warning/prompt

**Actual**
vbuild prompts `Something is already running on port 4000`
(but still starts the dev server on 3000)
