### PR TITLE
Stop ignoring errors inside vue.config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 'use strict'
-const Path = require('path')
+const path = require('path')
 const pathExists = require('path-exists')
 const co = require('co')
 const chalk = require('chalk')
@@ -10,10 +10,9 @@ const test = require('./test')
 const updateConfig = require('./update-config')
 const detectFreePort = require('./detect-free-port')
 const mergeConfig = require('./merge-config')
-const _ = require('./utils')
 
 module.exports = co.wrap(function * (options) {
-  const configFilePath = Path.resolve(options.config || 'vue.config')
+  const configFilePath = path.resolve(options.config || 'vue.config')
 
   let fileConfig
   let devConfig

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,10 +24,10 @@ module.exports = co.wrap(function * (options) {
   let prodConfig
   if (options.config !== false) {
     const configFilePath = options.config || defaultConfigPath
-    let resolvedConfigFilePath = _.cwd(configFilePath)
-    if ( fs.existsSync(resolvedConfigFilePath) ||
-         fs.existsSync(resolvedConfigFilePath + '.js') ||
-         fs.existsSync(resolvedConfigFilePath + '.json') ) {
+    const resolvedConfigFilePath = _.cwd(configFilePath)
+    if (fs.existsSync(resolvedConfigFilePath) ||
+        fs.existsSync(resolvedConfigFilePath + '.js') ||
+        fs.existsSync(resolvedConfigFilePath + '.json')) {
       fileConfig = require(resolvedConfigFilePath)
       options.config = configFilePath
     } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 'use strict'
+const fs = require('fs')
 const Path = require('path')
 const co = require('co')
 const chalk = require('chalk')
@@ -23,17 +24,16 @@ module.exports = co.wrap(function * (options) {
   let prodConfig
   if (options.config !== false) {
     const configFilePath = options.config || defaultConfigPath
-    try {
-      fileConfig = require(_.cwd(configFilePath))
+    let resolvedConfigFilePath = _.cwd(configFilePath)
+    if ( fs.existsSync(resolvedConfigFilePath) ||
+         fs.existsSync(resolvedConfigFilePath + '.js') ||
+         fs.existsSync(resolvedConfigFilePath + '.json') ) {
+      fileConfig = require(resolvedConfigFilePath)
       options.config = configFilePath
-    } catch (err) {
-      if (err.code === 'MODULE_NOT_FOUND') {
-        options.config = options.config === undefined ?
-          false :
-          chalk.red(`[not found] ${configFilePath}`)
-      } else {
-        throw err
-      }
+    } else {
+      options.config = options.config === undefined ?
+        false :
+        chalk.red(`[not found] ${configFilePath}`)
     }
 
     if (fileConfig) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,5 @@
 'use strict'
-const fs = require('fs')
+const pathExists = require('path-exists')
 const Path = require('path')
 const co = require('co')
 const chalk = require('chalk')
@@ -25,9 +25,9 @@ module.exports = co.wrap(function * (options) {
   if (options.config !== false) {
     const configFilePath = options.config || defaultConfigPath
     const resolvedConfigFilePath = _.cwd(configFilePath)
-    if (fs.existsSync(resolvedConfigFilePath) ||
-        fs.existsSync(resolvedConfigFilePath + '.js') ||
-        fs.existsSync(resolvedConfigFilePath + '.json')) {
+    if (pathExists.sync(resolvedConfigFilePath) ||
+        pathExists.sync(resolvedConfigFilePath + '.js') ||
+        pathExists.sync(resolvedConfigFilePath + '.json')) {
       fileConfig = require(resolvedConfigFilePath)
       options.config = configFilePath
     } else {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,6 @@
 'use strict'
-const pathExists = require('path-exists')
 const Path = require('path')
+const pathExists = require('path-exists')
 const co = require('co')
 const chalk = require('chalk')
 const merge = require('lodash.merge')

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const pathExists = require('path-exists')
 const co = require('co')
 const chalk = require('chalk')
 const merge = require('lodash.merge')
+const tildify = require('tildify')
 const build = require('./build')
 const dev = require('./dev')
 const test = require('./test')
@@ -18,7 +19,8 @@ module.exports = co.wrap(function * (options) {
   let devConfig
   let prodConfig
   if (options.config !== false) {
-    if (pathExists.sync(configFilePath) ||
+    const isValid = /\.(js|json)$/.test(configFilePath) && pathExists.sync(configFilePath)
+    if (isValid ||
         pathExists.sync(configFilePath + '.js') ||
         pathExists.sync(configFilePath + '.json')) {
       fileConfig = require(configFilePath)
@@ -26,7 +28,7 @@ module.exports = co.wrap(function * (options) {
     } else {
       options.config = options.config === undefined ?
         false :
-        chalk.red(`[not found] ${configFilePath}`)
+        chalk.red(`[not found] ${tildify(configFilePath)}`)
     }
 
     if (fileConfig) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -13,22 +13,16 @@ const mergeConfig = require('./merge-config')
 const _ = require('./utils')
 
 module.exports = co.wrap(function * (options) {
-  const defaultConfigPath = Path.resolve(
-    typeof options.config === 'string' ?
-      options.config :
-      'vue.config'
-  )
+  const configFilePath = Path.resolve(options.config || 'vue.config')
 
   let fileConfig
   let devConfig
   let prodConfig
   if (options.config !== false) {
-    const configFilePath = options.config || defaultConfigPath
-    const resolvedConfigFilePath = _.cwd(configFilePath)
-    if (pathExists.sync(resolvedConfigFilePath) ||
-        pathExists.sync(resolvedConfigFilePath + '.js') ||
-        pathExists.sync(resolvedConfigFilePath + '.json')) {
-      fileConfig = require(resolvedConfigFilePath)
+    if (pathExists.sync(configFilePath) ||
+        pathExists.sync(configFilePath + '.js') ||
+        pathExists.sync(configFilePath + '.json')) {
+      fileConfig = require(configFilePath)
       options.config = configFilePath
     } else {
       options.config = options.config === undefined ?


### PR DESCRIPTION
If I create a vue.config.js like this:
```javascript
const webpack = require('webpack')
module.exports = {
  title: 'todo',
  resolve: true,
  open: false,
  plugins: [
    new webpack.DefinePlugin({
      VERSION: '"1.2.3"'
    })
  ]
}
```

It will fail to load config when webpack is not a dependency and vbuild is running globally as usual.
That's because it will raise a MODULE_NOT_FOUND error that is miss interpreted as config file not found, and nothing is printed.
This pull request try to fix that, but keep the default behavior to support .js and .json config files.

Please, let me know if I need to better explain myself