### PR TITLE
Use async attribute on script tag.

### DIFF
--- a/lib/template.html
+++ b/lib/template.html
@@ -12,7 +12,7 @@
   <body>
     <div id="app"></div>
     <% htmlWebpackPlugin.files.js.forEach(function (js) { %>
-    <script src="<%=js%>"></script>
+    <script src="<%=js%>" async></script>
     <% }) %>
     <% if (htmlWebpackPlugin.options.ga){ %>
     <script>


### PR DESCRIPTION
https://twitter.com/addyosmani/status/808713528160813056

Because by default this template specifically has only one script tag it relies on (besides GA which should be independent anyway) I believe `async` is the best option to use. But then again if you split the build into more chunks maybe we should use `defer` instead. More info [here](http://www.growingwiththeweb.com/2014/02/async-vs-defer-attributes.html#when-should-i-use-what). What do you think?