### PR TITLE
Proxy

### DIFF
--- a/lib/dev.js
+++ b/lib/dev.js
@@ -17,9 +17,7 @@ module.exports = co.wrap(function * (webpackConfig, options) {
     chalk.cyan(`> ${options.title || 'vbuild'} is running at ${chalk.underline(url)}`) + '\n\n' + tip + '\n\n' + stats + '\n'
   )
 
-  const app = server(webpackConfig, options)
-
-  app.listen(port, host === 'all' ? '0.0.0.0' : host)
+  const app = server(webpackConfig, options) // eslint-disable-line no-unused-vars
 
   if (options.open) {
     yield opn(url)

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,6 +3,7 @@ const path = require('path')
 const express = require('express')
 const webpack = require('webpack')
 const httpProxyMiddleware = require('http-proxy-middleware')
+const historyApiFallback = require('connect-history-api-fallback')
 const chalk = require('chalk')
 
 module.exports = function (webpackConfig, options) {
@@ -90,6 +91,13 @@ function onProxyError(proxy) {
 }
 
 function addProxyMiddleware(devServer, proxy) {
+  //if proxy is specified we fallback to index.html if request `accept`s text/html
+  //so proxy works with vue-router or other client routing libraries
+  devServer.use(historyApiFallback({
+    disableDotRule: true,
+    htmlAcceptHeaders: ['text/html']
+  }))
+
   // There are a few exceptions which we won't send to the proxy:
   const mayProxy = /^(?!\/(index\.html$|favicon.ico|.*\.hot-update\.json$|sockjs-node\/)).*$/
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -2,6 +2,8 @@
 const path = require('path')
 const express = require('express')
 const webpack = require('webpack')
+const httpProxyMiddleware = require('http-proxy-middleware')
+const chalk = require('chalk')
 
 module.exports = function (webpackConfig, options) {
   const app = express()
@@ -26,6 +28,14 @@ module.exports = function (webpackConfig, options) {
     options.devServer(app)
   }
 
+  const proxy = options.proxy
+  let hpm = null
+  if (proxy) {
+    checkProxy(proxy)
+
+    hpm = addProxyMiddleware(app, proxy)
+  }
+
   app.get('*', (req, res) => {
     devMiddleWare.waitUntilValid(() => {
       const html = mfs.readFileSync(file)
@@ -33,5 +43,76 @@ module.exports = function (webpackConfig, options) {
     })
   })
 
+  const port = options.port
+  const host = options.host
+  const appServer = app.listen(port, host === 'all' ? '0.0.0.0' : host)
+
+  if (proxy) {
+    // Listen for the websocket 'upgrade' event and upgrade the connection.
+    appServer.on('upgrade', hpm.upgrade)
+  }
+
   return app
+}
+
+function checkProxy(proxy) {
+  if (typeof proxy !== 'string') {
+    console.log(chalk.red('When specified, "proxy" must be a string.'))
+    console.log(chalk.red(`Instead, the type of "proxy" was "${typeof proxy}".`))
+    console.log(chalk.red('Either remove "proxy" from config file, or make it a string.'))
+    process.exit(1) // eslint-disable xo/no-process-exit
+  }
+}
+
+// Custom onError function for httpProxyMiddleware to log custom error messages on the console.
+function onProxyError(proxy) {
+  return function (err, req, res) {
+    const host = req.headers && req.headers.host
+    console.log(
+      chalk.red('Proxy error:') + ' Could not proxy request ' + chalk.cyan(req.url) +
+      ' from ' + chalk.cyan(host) + ' to ' + chalk.cyan(proxy) + '.'
+    )
+    console.log(
+      'See https://nodejs.org/api/errors.html#errors_common_system_errors for more information (' +
+      chalk.cyan(err.code) + ').'
+    )
+    console.log()
+
+    // And immediately send the proper error response to the client.
+    // Otherwise, the request will eventually timeout with ERR_EMPTY_RESPONSE on the client side.
+    if (res.writeHead && !res.headersSent) {
+      res.writeHead(500)
+    }
+    res.end('Proxy error: Could not proxy request ' + req.url + ' from ' +
+      host + ' to ' + proxy + ' (' + err.code + ').'
+    )
+  }
+}
+
+function addProxyMiddleware(devServer, proxy) {
+  // There are a few exceptions which we won't send to the proxy:
+  const mayProxy = /^(?!\/(index\.html$|favicon.ico|.*\.hot-update\.json$|sockjs-node\/)).*$/
+
+  // Pass the scope regex both to Express and to the middleware for proxying
+  // of both HTTP and WebSockets to work without false positives.
+  const hpm = httpProxyMiddleware(pathname => mayProxy.test(pathname), {
+    target: proxy,
+    logLevel: 'silent',
+    onProxyReq(proxyReq) {
+      // Browsers may send Origin headers even with same-origin
+      // requests. To prevent CORS issues, we have to change
+      // the Origin to match the target URL.
+      if (proxyReq.getHeader('origin')) {
+        proxyReq.setHeader('origin', proxy)
+      }
+    },
+    onError: onProxyError(proxy),
+    secure: false,
+    changeOrigin: true,
+    ws: true
+  })
+
+  devServer.use(mayProxy, hpm)
+
+  return hpm
 }

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "chalk": "^1.1.3",
     "co": "^4.6.0",
     "compression-webpack-plugin": "^0.3.2",
+    "connect-history-api-fallback": "^1.3.0",
     "copy-webpack-plugin": "^4.0.1",
     "css-loader": "^0.25.0",
     "detect-installed": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "fs-promise": "^0.5.0",
     "graceful-copy": "^1.0.1",
     "html-webpack-plugin": "^2.22.0",
+    "http-proxy-middleware": "^0.17.3",
     "installed-by-yarn-globally": "^0.1.0",
     "internal-ip": "^1.2.0",
     "json-loader": "^0.5.4",


### PR DESCRIPTION
#14 Add proxy mappings 
proxy mapping for single entry proxy option

Notes:
Implementation based on implementation in create-react-app project
To be able to subscribe to 'upgrade' for express server I had to move app.listen call from dev.js to server.js
Currently if proxy is not a string, vbuild would exit with a warning message (maybe should be handled differently)
