### PR TITLE
vbuild test inputFiles resulted in true

### DIFF
--- a/lib/test.js
+++ b/lib/test.js
@@ -4,7 +4,7 @@ const _ = require('./utils')
 module.exports = function (webpackConfig, options) {
   const Server = require(_.cwd('node_modules/karma')).Server
 
-  const inputFiles = options.inputFiles.length > 0 || ['./src/**/*', './tests/**/*.test.js']
+  const inputFiles = options.inputFiles || ['./src/**/*', './tests/**/*.test.js']
 
   let karmaConfig = options.karmaConfig
 


### PR DESCRIPTION
When defining `inputFiles`, output was a Boolean
```js
options.inputFiles.length > 0 = Boolean
```