### PR TITLE
load config before env

### DIFF
--- a/bin/vbuild-start.js
+++ b/bin/vbuild-start.js
@@ -78,8 +78,8 @@ module.exports = function (cliOptions) {
   const start = co.wrap(function * () {
     const defaultBabelOptions = loadBabelConfig()
     const defaultPostcssOptions = yield loadPostCSSConfig()
-    const defaultEnv = yield loadEnv(cliOptions)
     const config = yield loadConfig(cliOptions)
+    const defaultEnv = yield loadEnv(cliOptions)
 
     const options = Object.assign({
       babel: defaultBabelOptions,


### PR DESCRIPTION
Otherwise, setting `options.env = false` is ignored in `vbuild.config.js`.

In a Laravel project, `vbuild` is reading my `.env` file & I don't want it to. Currently, it's not possible to turn off the `env` feature.